### PR TITLE
test(runtime): isolate build guards from host tools

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -824,7 +824,9 @@ def test_runtime_refuses_symlinked_build_sources(tmp_path: Path) -> None:
     plan = plan_runtime(
         repo_root,
         home,
-        executable_finder=lambda tool: f"/fake/{tool}",
+        executable_finder=lambda tool: (
+            f"/fake/{tool}" if tool in {"cargo", "git"} else None
+        ),
         network=False,
         build=True,
     )
@@ -965,7 +967,9 @@ def test_runtime_rechecks_build_source_before_execution(tmp_path: Path) -> None:
     plan = plan_runtime(
         repo_root,
         home,
-        executable_finder=lambda tool: f"/fake/{tool}",
+        executable_finder=lambda tool: (
+            f"/fake/{tool}" if tool in {"cargo", "git"} else None
+        ),
         network=False,
         build=True,
     )
@@ -999,7 +1003,9 @@ def test_runtime_rechecks_build_source_git_metadata_before_execution(
     plan = plan_runtime(
         repo_root,
         home,
-        executable_finder=lambda tool: f"/fake/{tool}",
+        executable_finder=lambda tool: (
+            f"/fake/{tool}" if tool in {"cargo", "git"} else None
+        ),
         network=False,
         build=True,
     )


### PR DESCRIPTION
## Summary

Keep runtime guard tests isolated from host-installed generator tools. The change narrows three fake executable finders to the `cargo` and `git` commands their scenarios actually exercise.

## Breaking Changes

无。仅修改测试 fixture 的工具发现范围，不改变 runtime 生产代码、CLI 或序列化契约。

## Problem

Three build-safety tests reported every runtime generator as available, then executed the generated plan using bare command names from the real host `PATH`. Hosts without those tools failed fast, but an Arch host with more generators installed spent about 21 seconds in each test and pushed the full pytest run to about 71 seconds.

## Solution

Expose only `cargo` and `git` through the fixture's fake executable finder. This preserves the source and Git-metadata guard scenarios while preventing unrelated host tools from entering their execution plans.

## Related

- Amp thread: https://ampcode.com/threads/T-019f7fb2-778b-74c8-9e2d-5e8a96679e0a

## Verification

- `mise run verify` on macOS: 187 tests passed; Ruff, formatting, ty, repository lint, shell checks, and all standalone module suites passed.
- Three targeted runtime tests: 3 passed in 0.20 seconds locally and 0.18 seconds on `ser9pro`.
- Full pytest on `ser9pro`: 186 passed, 1 skipped in 8.98 seconds, down from about 71 seconds on the unmodified fixtures.
- `ruff check tests/test_runtime.py`, `ruff format --check tests/test_runtime.py`, and `git diff --check` passed.
